### PR TITLE
Include archive name in result

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ import { createTarball } from '@ronin/tarball';
 const files = [
   {
     name: 'hello.txt',
-    contents: new Uint8Array(Buffer.from('Hello World')),
+    contents: new Uint8Array(new TextEncoder().encode('Hello World')),
   },
 ];
 
 const tarball = createTarball('archive.tar.gz', files);
-//     ^? Uint8Array<ArrayBuffer>
+//       ^? { name: 'archive.tar.gz', contents: Uint8Array<ArrayBuffer> }
 ```
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ const files = [
 ];
 
 const tarball = createTarball('archive.tar.gz', files);
-//       ^? { name: 'archive.tar.gz', contents: Uint8Array<ArrayBuffer> }
+//       ^? { name: 'archive.tar.gz', data: Uint8Array<ArrayBuffer> }
 ```
 
 ## Testing

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,12 @@
 import { buildHeaderRecord, calculateTarballByteLength } from '@/src/utils';
 import { zip as gzip } from 'gzip-js';
 
-import type { CreateTarballOptions, TarballInputFile } from '@/src/types';
+import type {
+  CreateTarballOptions,
+  CreateTarballResult,
+  Prettify,
+  TarballInputFile,
+} from '@/src/types';
 
 /**
  * Create a tarball from a list of files
@@ -10,13 +15,16 @@ import type { CreateTarballOptions, TarballInputFile } from '@/src/types';
  * @param files - The list of files to include in the tarball
  * @param [options] - The options for creating the tarball
  *
- * @returns The tarball as a Uint8Array
+ * @returns An object containing the tarball data and file name.
  */
-export const createTarball = <T extends Array<TarballInputFile>>(
-  name: string,
-  files: T,
+export const createTarball = <
+  TName extends string,
+  TFiles extends Array<TarballInputFile>,
+>(
+  name: TName,
+  files: TFiles,
   options?: CreateTarballOptions,
-): Uint8Array<ArrayBuffer> => {
+): Prettify<CreateTarballResult<TName>> => {
   const { compress = true, timestamp } = options ?? {};
 
   const tarballByteLength = calculateTarballByteLength(files);
@@ -35,8 +43,15 @@ export const createTarball = <T extends Array<TarballInputFile>>(
       name,
       timestamp,
     });
-    return new Uint8Array(gzipTarball);
+
+    return {
+      name,
+      data: new Uint8Array(gzipTarball),
+    };
   }
 
-  return tarballByteArr;
+  return {
+    name,
+    data: tarballByteArr,
+  };
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+export type Prettify<T> = { [K in keyof T]: T[K] } & {};
+
 export interface TarballInputFile {
   /**
    * The contents of the file.
@@ -34,4 +36,16 @@ export interface CreateTarballOptions {
    * The default value is the package version timestamp.
    */
   timestamp: number;
+}
+
+export interface CreateTarballResult<TName extends string> {
+  /**
+   * The tarball data as a Uint8Array.
+   */
+  data: Uint8Array<ArrayBuffer>;
+
+  /**
+   * The name of the tarball.
+   */
+  name: TName;
 }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -38,8 +38,9 @@ describe('create', () => {
         timestamp: CREATED_AT_TIMESTAMP,
       },
     );
-    const tarballHash = await getIntegrityHash(tarball);
+    expect(tarball.name).toStrictEqual('basic.tar.gz');
 
+    const tarballHash = await getIntegrityHash(tarball.data);
     expect(tarballHash).toMatchSnapshot();
   });
 
@@ -47,18 +48,20 @@ describe('create', () => {
     const tarball = createTarball('empty.tar.gz', [], {
       timestamp: CREATED_AT_TIMESTAMP,
     });
-    const tarballHash = await getIntegrityHash(tarball);
+    expect(tarball.name).toStrictEqual('empty.tar.gz');
 
+    const tarballHash = await getIntegrityHash(tarball.data);
     expect(tarballHash).toMatchSnapshot();
   });
 
   test('an uncompressed tarball', async () => {
-    const tarball = createTarball('basic.tar.gz', [], {
+    const tarball = createTarball('uncompressed.tar', [], {
       compress: false,
       timestamp: CREATED_AT_TIMESTAMP,
     });
-    const tarballHash = await getIntegrityHash(tarball);
+    expect(tarball.name).toStrictEqual('uncompressed.tar');
 
+    const tarballHash = await getIntegrityHash(tarball.data);
     expect(tarballHash).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
This changes updates the result of `createTarball` to instead return an object containing the data of the tarball itself, as well as the tarball name that is used when compressing it.

Additionally some minor tweaks to the `README.md` 