### PR TITLE
Export input tarball file type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,8 @@ import { zip as gzip } from 'gzip-js';
 
 import type { CreateTarballOptions, TarballInputFile } from '@/src/types';
 
+export type { TarballInputFile } from '@/src/types';
+
 /**
  * Create a tarball from a list of files
  *


### PR DESCRIPTION
This change exports the `TarballInputFile` type used by `createTarball` so you can construct a valid typed array without needing to directly pass it into `createTarball`.