### PR TITLE
Simplified usage snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ import { createTarball } from '@ronin/tarball';
 const files = [
   {
     name: 'hello.txt',
-    contents: new Uint8Array(new TextEncoder().encode('Hello World')),
+    contents: new TextEncoder().encode('Hello World'),
   },
 ];
 


### PR DESCRIPTION
This change updates the usage code snippet in the `README.md` to remove the unnecessary wrapping of `new Uint8Array()`