### PR TITLE
Simplify tarball creation syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 This package generates a tarball file in-memory, with the ability to compress it using gzip.
 
 ## Usage
+
 ```typescript
 import { createTarball } from '@ronin/tarball';
 
@@ -17,8 +18,8 @@ const files = [
   },
 ];
 
-const tarball = createTarball('archive.tar.gz', files);
-//       ^? { name: 'archive.tar.gz', data: Uint8Array<ArrayBuffer> }
+const tarball = createTarball(files);
+//       ^? { name: null, data: Uint8Array<ArrayBuffer> }
 ```
 
 ## Testing

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,14 +20,13 @@ export type { TarballInputFile } from '@/src/types';
  * @returns An object containing the tarball data and file name.
  */
 export const createTarball = <
-  TName extends string,
   TFiles extends Array<TarballInputFile>,
+  TName extends string | null = null,
 >(
-  name: TName,
   files: TFiles,
-  options?: CreateTarballOptions,
+  options?: CreateTarballOptions<TName>,
 ): Prettify<CreateTarballResult<TName>> => {
-  const { compress = true, timestamp } = options ?? {};
+  const { compress = true, name = null, timestamp } = options ?? {};
 
   const tarballByteLength = calculateTarballByteLength(files);
   const tarballByteArr = new Uint8Array(tarballByteLength);
@@ -40,20 +39,19 @@ export const createTarball = <
     offset += Math.ceil(file.contents.byteLength / 512) * 512 + 512;
   }
 
-  if (compress) {
-    const gzipTarball = gzip(tarballByteArr, {
-      name,
-      timestamp,
-    });
-
+  if (!compress)
     return {
-      name,
-      data: new Uint8Array(gzipTarball),
+      data: tarballByteArr,
+      name: name as TName,
     };
-  }
+
+  const gzipTarball = gzip(tarballByteArr, {
+    name: name ?? undefined,
+    timestamp,
+  });
 
   return {
-    name,
-    data: tarballByteArr,
+    data: new Uint8Array(gzipTarball),
+    name: name as TName,
   };
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,13 +19,20 @@ export interface TarballInputFile {
   lastModifiedAt?: Date;
 }
 
-export interface CreateTarballOptions {
+export interface CreateTarballOptions<TName extends string | null> {
   /**
    * Whether to compress the tarball using gzip or not
    *
    * @default true
    */
   compress?: boolean;
+
+  /**
+   * The name of the tarball.
+   *
+   * This property is primarily used for gzip compression.
+   */
+  name?: TName;
 
   /**
    * The timestamp at which the tarball was created.
@@ -35,10 +42,10 @@ export interface CreateTarballOptions {
    *
    * The default value is the package version timestamp.
    */
-  timestamp: number;
+  timestamp?: number;
 }
 
-export interface CreateTarballResult<TName extends string> {
+export interface CreateTarballResult<TName extends string | null> {
   /**
    * The tarball data as a Uint8Array.
    */

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -5,3 +5,5 @@ exports[`create a basic tarball 1`] = `"sha512-ZgtIFb/6PHovvz1IGB/8IUHmvQhnJXZcy
 exports[`create an empty tarball 1`] = `"sha512-TbZfkhWIV5aDktJFZIchaMbYctV8kqCHMy2LgGKO0K0tfM0yXRNRvYitFlqim2LXb9MVoZuQSJOc7lcWeL/D1w=="`;
 
 exports[`create an uncompressed tarball 1`] = `"sha512-jvtPc8VlU1HEROsQkjDFVtOeLHYk6cEavJ4/tLm5JUIYzFCFtFSpaY0IXPqSGYSR8HpyO+RXStxwYXtz6wtkYQ=="`;
+
+exports[`create a basic npm package 1`] = `"sha512-OpWTBou59cdxmAVJKUAUAwmVE8Gqv3zcQ7oqt8WjbCVAYg5q0UrMAYfLzGclxQji6Ui26A2Csj94v7UTsw8aSg=="`;

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -7,3 +7,5 @@ exports[`create an empty tarball 1`] = `"sha512-TbZfkhWIV5aDktJFZIchaMbYctV8kqCH
 exports[`create an uncompressed tarball 1`] = `"sha512-jvtPc8VlU1HEROsQkjDFVtOeLHYk6cEavJ4/tLm5JUIYzFCFtFSpaY0IXPqSGYSR8HpyO+RXStxwYXtz6wtkYQ=="`;
 
 exports[`create a basic npm package 1`] = `"sha512-OpWTBou59cdxmAVJKUAUAwmVE8Gqv3zcQ7oqt8WjbCVAYg5q0UrMAYfLzGclxQji6Ui26A2Csj94v7UTsw8aSg=="`;
+
+exports[`create an empty name 1`] = `"sha512-Qmaw8wcsenf2c+JhSrFrii4mLt5srb1q26Slrw3xp3ZEYuBENcTHlN1a5ixXDZZ/ZhM6gwS8qmOQKFTJkIWTmQ=="`;

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -84,6 +84,16 @@ describe('create', () => {
     expect(tarballHash).toMatchSnapshot();
   });
 
+  test('an empty name', async () => {
+    const tarball = createTarball([], {
+      timestamp: CREATED_AT_TIMESTAMP,
+    });
+    expect(tarball.name).toStrictEqual(null);
+
+    const tarballHash = await getIntegrityHash(tarball.data);
+    expect(tarballHash).toMatchSnapshot();
+  });
+
   test('an empty tarball', async () => {
     const tarball = createTarball([], {
       name: 'empty.tar.gz',

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -24,13 +24,15 @@ const getIntegrityHash = async (
 // the integrity hash remains consistent across test runs.
 const CREATED_AT_TIMESTAMP = new Date('2025-01-01T00:00:00.000Z').getTime();
 
+const encoder = new TextEncoder();
+
 describe('create', () => {
   test('a basic tarball', async () => {
     const tarball = createTarball(
       [
         {
           name: 'hello-world.txt',
-          contents: new Uint8Array(Buffer.from('Hello, world!', 'utf-8')),
+          contents: encoder.encode('Hello, world!'),
         },
       ],
       {
@@ -39,6 +41,44 @@ describe('create', () => {
       },
     );
     expect(tarball.name).toStrictEqual('basic.tar.gz');
+
+    const tarballHash = await getIntegrityHash(tarball.data);
+    expect(tarballHash).toMatchSnapshot();
+  });
+
+  test('a basic npm package', async () => {
+    const tarball = createTarball(
+      [
+        {
+          name: 'package/package.json',
+          contents: encoder.encode(
+            JSON.stringify({
+              private: true,
+              name: '@ronin/example',
+              version: '0.0.0',
+              main: 'index.js',
+              types: 'index.d.ts',
+            }),
+          ),
+        },
+        {
+          name: 'package/index.js',
+          contents: encoder.encode('export const add = (a, b) => a + b;'),
+        },
+        {
+          name: 'package/index.d.ts',
+          contents: encoder.encode(
+            `declare const add: (a: number, b: number) => number;
+            export { add };`,
+          ),
+        },
+      ],
+      {
+        name: 'package.tar.gz',
+        timestamp: CREATED_AT_TIMESTAMP,
+      },
+    );
+    expect(tarball.name).toStrictEqual('package.tar.gz');
 
     const tarballHash = await getIntegrityHash(tarball.data);
     expect(tarballHash).toMatchSnapshot();

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -27,7 +27,6 @@ const CREATED_AT_TIMESTAMP = new Date('2025-01-01T00:00:00.000Z').getTime();
 describe('create', () => {
   test('a basic tarball', async () => {
     const tarball = createTarball(
-      'basic.tar.gz',
       [
         {
           name: 'hello-world.txt',
@@ -35,6 +34,7 @@ describe('create', () => {
         },
       ],
       {
+        name: 'basic.tar.gz',
         timestamp: CREATED_AT_TIMESTAMP,
       },
     );
@@ -45,7 +45,8 @@ describe('create', () => {
   });
 
   test('an empty tarball', async () => {
-    const tarball = createTarball('empty.tar.gz', [], {
+    const tarball = createTarball([], {
+      name: 'empty.tar.gz',
       timestamp: CREATED_AT_TIMESTAMP,
     });
     expect(tarball.name).toStrictEqual('empty.tar.gz');
@@ -55,8 +56,9 @@ describe('create', () => {
   });
 
   test('an uncompressed tarball', async () => {
-    const tarball = createTarball('uncompressed.tar', [], {
+    const tarball = createTarball([], {
       compress: false,
+      name: 'uncompressed.tar',
       timestamp: CREATED_AT_TIMESTAMP,
     });
     expect(tarball.name).toStrictEqual('uncompressed.tar');


### PR DESCRIPTION
This PR both makes a few minor refactoring changes to clean up the code and adds an additional integration test to mimic a more real-world use case.

Additionally it updates the syntax / api of the `createTarball` function to make the tarball name not be required anymore